### PR TITLE
Issue/1

### DIFF
--- a/glslib/globbing.py
+++ b/glslib/globbing.py
@@ -6,6 +6,7 @@ import subprocess
 import glob
 import re
 import pwd
+import grp
 import time
 
 
@@ -234,7 +235,7 @@ def get_sys_status(lfiles, human=False):
                               for m, M in zip(mode, "rwxrwxrwx")])
         stat = os.stat(lfile)
         owner = pwd.getpwuid(stat.st_uid).pw_name
-        group = pwd.getpwuid(stat.st_gid).pw_name
+        group = grp.getgrgid(stat.st_gid).gr_name 
 
         size = format_filesize(stat.st_size, human)
 

--- a/glslib/globbing.py
+++ b/glslib/globbing.py
@@ -197,9 +197,9 @@ def format_time(mtime):
     six_months_ago = time.time() - 180*24*60
 
     if mtime > six_months_ago:
-        return time.strftime("%b;%d %H:%I", mtime).split(";")
+        return time.strftime("%b;%d %H:%I", time.localtime(mtime)).split(";")
 
-    return time.strftime("%b;%d  %Y", mtime).split(";")
+    return time.strftime("%b;%d  %Y", time.localtime(mtime)).split(";")
 
 
 def get_sys_status(lfiles, human=False):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from distutils.core import setup
 
 setup(
     name='gls',
-    version='0.3',
+    version='0.3.1',
     packages=['glslib'],
     scripts=['gls'],
     url='http://github.com/jonathf/gls',


### PR DESCRIPTION
Contains two fixes, that prevented correct display of long listing format. One caused script to fail when retrieving group name, other when formatting access time.

Found and fixed on Python 2.7.15, macOS.